### PR TITLE
Removed /nick restrictions; added chat logging for both nicknames and original player names

### DIFF
--- a/plugins/chat_logger.py
+++ b/plugins/chat_logger.py
@@ -27,6 +27,7 @@ class ChatLogger(BasePlugin):
         :return: Boolean; Always true.
         """
         message = data["parsed"]["message"]
-        # FezzedOne: Log entry format is `<NICK> [<ORIGINAL NAME>]: <MESSAGE>`.
-        self.logger.info("{} [{}]: {}".format(connection.player.alias, connection.player.name, message))
+        # FezzedOne: Log entry format is `<NICK> [<ORIGINAL NAME>] {<UUID>}: <MESSAGE>`.
+        self.logger.info("{} [{}] {{{}}}: {}".format(connection.player.alias, connection.player.name,
+                                                     connection.player.uuid, message))
         return True

--- a/plugins/chat_logger.py
+++ b/plugins/chat_logger.py
@@ -27,5 +27,6 @@ class ChatLogger(BasePlugin):
         :return: Boolean; Always true.
         """
         message = data["parsed"]["message"]
-        self.logger.info("{}: {}".format(connection.player.name, message))
+        # FezzedOne: Log entry format is `<NICK> [<ORIGINAL NAME>]: <MESSAGE>`.
+        self.logger.info("{} [{}]: {}".format(connection.player.alias, connection.player.name, message))
         return True

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -231,19 +231,19 @@ class GeneralCommands(SimpleCommandPlugin):
             target = connection.player
         if len(data) == 0:
             alias = connection.player.name
-        conflict = self.plugins.player_manager.get_player_by_alias(alias)
-        if conflict and target != conflict:
-            raise ValueError("There's already a user by that name.")
-        else:
-            clean_alias = self.plugins['player_manager'].clean_name(alias)
-            if clean_alias is None:
-                send_message(connection,
-                             "Nickname contains no valid characters.")
-                return
-            old_alias = target.alias
-            target.alias = clean_alias
-            broadcast(connection, "{}'s name has been changed to {}".format(
-                old_alias, clean_alias))
+        # conflict = self.plugins.player_manager.get_player_by_alias(alias)
+        # if conflict and target != conflict:
+        #     raise ValueError("There's already a user by that name.")
+        # else:
+        clean_alias = self.plugins['player_manager'].clean_name(alias)
+        if clean_alias is None:
+            send_message(connection,
+                         "Nickname contains no valid characters.")
+            return
+        old_alias = target.alias
+        target.alias = clean_alias
+        broadcast(connection, "{}'s name has been changed to {}".format(
+            old_alias, clean_alias))
 
     @Command("serverwhoami",
              perm="general_commands.whoami",

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -864,8 +864,8 @@ class PlayerManager(SimpleCommandPlugin):
             p.update_ranks(self.ranks)
             return p
         else:
-            if self.get_player_by_alias(alias) is not None:
-                raise NameError("A user with that name already exists.")
+            # if self.get_player_by_alias(alias) is not None:
+            #     raise NameError("A user with that name already exists.")
             self.logger.info("Adding new player to database: {} (UUID:{})"
                              "".format(alias, uuid))
             if uuid == self.plugin_config.owner_uuid:


### PR DESCRIPTION
This should solve the issue that `/nick`s anti-impersonation measures originally tried (and failed) to solve, without annoying players who use xStarbound and xPlayer to swap characters and «multi-client». Ensure you enable StarryPy3k's chat logging plugin after merging this PR.

Chat log messages in StarryPy's log will be in the format `<NICK> [<ORIGINAL NAME>] {<UUID>}: <MESSAGE>`. Example:

```log
Fezzy [FezzedOne] {486900ece20efeba73bab78a4431f281}: Hello there!
```